### PR TITLE
Adjust leaderboard layout and add previous period data

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1011,10 +1011,23 @@ footer.pl-rail {
   right: 14px;
 }
 
+.podium-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+}
+
 .meta {
-  text-align: right;
+  text-align: center;
   margin-left: auto;
+  margin-right: auto;
   color: #dfe6ff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding-top: 12px;
 }
 
 .meta .lab {

--- a/pages/leaderboard.php
+++ b/pages/leaderboard.php
@@ -141,15 +141,11 @@ if ($encodedSession === false) {
               <span class="pill right"><i data-lucide="medal" class="w-4 h-4"></i> 2nd</span>
 
               <div class="flex items-start justify-between gap-4">
-                <div>
-                  <br>
-                  <br>  
+                <div class="podium-summary">
                   <div class="rank">#2</div>
                   <div class="name" id="p2-name">—</div>
                 </div>
                 <div class="meta">
-                  <br>
-                  <br>
                   <div class="lab">Wagered</div>
                   <div class="val" id="p2-wager">$0</div>
                   <div class="lab mt-1">Prize</div>
@@ -192,18 +188,13 @@ if ($encodedSession === false) {
               <span class="pill right"><i data-lucide="crown" class="w-4 h-4"></i></span>
 
               <div class="flex items-start justify-between gap-4">
-                <div>
-                  <br>
-                  <br> 
+                <div class="podium-summary">
                   <div class="rank">#1</div>
                   <div class="name" id="p1-name">—</div>
                 </div>
                 <div class="meta">
-                  <br>
-                  <br> 
                   <div class="lab">Wagered</div>
                   <div class="val" id="p1-wager">$0</div>
-                  <br>
                   <div class="lab mt-1">Prize</div>
                   <div class="prize-chip" id="p1-prize-chip">
                    <span class="gift" aria-hidden="true">
@@ -244,15 +235,11 @@ if ($encodedSession === false) {
               <span class="pill right"><i data-lucide="medal" class="w-4 h-4"></i> 3rd</span>
 
               <div class="flex items-start justify-between gap-4">
-                <div>
-                  <br>
-                  <br> 
+                <div class="podium-summary">
                   <div class="rank">#3</div>
                   <div class="name" id="p3-name">—</div>
                 </div>
                 <div class="meta">
-                  <br>
-                  <br> 
                   <div class="lab">Wagered</div>
                   <div class="val" id="p3-wager">$0</div>
                   <div class="lab mt-1">Prize</div>


### PR DESCRIPTION
## Summary
- center the podium metadata layout for the top-three cards and remove spacer breaks in the leaderboard markup
- render a wager/prize header above the #4-#20 rows and update the client script to fetch cached data per range
- extend the leaderboard API to filter by monthly ranges, reusing current prizes and returning range metadata

## Testing
- php -l api/leaderboard.php
- php -l pages/leaderboard.php

------
https://chatgpt.com/codex/tasks/task_e_68ca556b81e4833281a54df03e590030